### PR TITLE
Replace stop and remove command with docker down.

### DIFF
--- a/rebuild.sh
+++ b/rebuild.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 
-docker-compose stop
-docker-compose rm --force
+docker-compose down
 docker-compose up -d --build


### PR DESCRIPTION
Hi

I test my app using this repo and the following are my test scripts.

``` sh
docker-compose -p ${RANDOM} -f docker/docker-compose.testing.yml run app
docker-compose -p ${RANDOM} -f docker/docker-compose.testing.yml down
```

I suggest `down` command better than `stop` and `rm` command. You don't need execute couple command.
